### PR TITLE
Add Renovate config to automatically update `cisagov/cyhy-core` default version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,22 +1,4 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
-  extends: ["config:recommended"],
-  // Dependabot keeps handling github-actions + pip; Renovate only manages the
-  // cyhy-core pin, so restrict it to the custom manager to avoid overlap.
-  enabledManagers: ["custom.regex"],
-  labels: ["dependencies"],
-  dependencyDashboard: true,
-  customManagers: [
-    {
-      customType: "regex",
-      managerFilePatterns: ["/^defaults/main\\.yml$/", "/^README\\.md$/"],
-      matchStrings: [
-        "cyhy_core_version:\\s*(?<currentValue>\\S+)", // defaults/main.yml
-        "cyhy\\\\?_core\\\\?_version[^`]*`(?<currentValue>[^`]+)`", // README table cell
-      ],
-      depNameTemplate: "cisagov/cyhy-core",
-      datasourceTemplate: "github-releases",
-      versioningTemplate: "semver-coerced", // handles the leading `v`
-    },
-  ],
+  extends: ["github>cisagov/ansible-role-cyhy-core//.github/renovate.json5"],
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,22 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: ["config:recommended"],
+  // Dependabot keeps handling github-actions + pip; Renovate only manages the
+  // cyhy-core pin, so restrict it to the custom manager to avoid overlap.
+  enabledManagers: ["custom.regex"],
+  labels: ["dependencies"],
+  dependencyDashboard: true,
+  customManagers: [
+    {
+      customType: "regex",
+      managerFilePatterns: ["/^defaults/main\\.yml$/", "/^README\\.md$/"],
+      matchStrings: [
+        "cyhy_core_version:\\s*(?<currentValue>\\S+)", // defaults/main.yml
+        "cyhy\\\\?_core\\\\?_version[^`]*`(?<currentValue>[^`]+)`", // README table cell
+      ],
+      depNameTemplate: "cisagov/cyhy-core",
+      datasourceTemplate: "github-releases",
+      versioningTemplate: "semver-coerced", // handles the leading `v`
+    },
+  ],
+}


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a Renovate configuration for this repository.

## 💭 Motivation and context ##

This config checks GitHub Releases and verifies that the role variable default (and its reference in the `README`) are both up to date; this is not something we can do using Dependabot.  This addition will save us the headache of manually updating this repository when a new release of [cisagov/cyhy-core](https://github.com/cisagov/cyhy-core) is created.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All new and existing tests pass.
